### PR TITLE
Only consider an option having proxy when both proxy host and port are set.

### DIFF
--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -113,7 +113,12 @@ public class MirrorOptions implements AWSCredentials {
     @Getter @Setter public String proxyHost = null;
     @Getter @Setter public int proxyPort = -1;
 
-    public boolean getHasProxy() { return proxyHost != null && proxyHost.trim().length() > 0; }
+    public boolean getHasProxy() {
+        boolean hasProxyHost = proxyHost != null && proxyHost.trim().length() > 0;
+        boolean hasProxyPort = proxyPort != -1;
+
+        return hasProxyHost && hasProxyPort;
+    }
 
     private long initMaxAge() {
 


### PR DESCRIPTION
This patch is to fix the a bug in parseArguments() where proxy port never get set when 

```
            } else if (line.trim().startsWith("secret_key")) {
                options.setAWSSecretKey(line.substring(line.indexOf("=") + 1).trim());
            } else if (!options.getHasProxy() && line.trim().startsWith("proxy_host")) {
                options.setProxyHost(line.substring(line.indexOf("=") + 1).trim()); <==== getHasProxy() will return true after this line
            } else if (!options.getHasProxy() && line.trim().startsWith("proxy_port")){
                options.setProxyPort(Integer.parseInt(line.substring(line.indexOf("=") + 1).trim()));
            }
```
