### PR TITLE
Added file to allow log configuration at runtime

### DIFF
--- a/s3s3mirror.bat
+++ b/s3s3mirror.bat
@@ -1,2 +1,2 @@
 @echo off
-java -Ds3s3mirror.version=1.2.5 -jar target/s3s3mirror-1.2.5-SNAPSHOT.jar %*
+java -Dlog4j.configuration=file:target/conf/log4j.xml -Ds3s3mirror.version=1.2.5 -jar target/s3s3mirror-1.2.5-SNAPSHOT.jar %*

--- a/s3s3mirror.sh
+++ b/s3s3mirror.sh
@@ -10,11 +10,11 @@ DEBUG=$1
 if [ "${DEBUG}" = "--debug" ] ; then
   # Run in debug mode
   shift   # remove --debug from options
-  java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005 ${VERSION_ARG} -jar "${JARFILE}" "$@"
+  java -Dlog4j.configuration=file:target/conf/log4j.xml -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005 ${VERSION_ARG} -jar "${JARFILE}" "$@"
 
 else
   # Run in regular mode
-  java ${VERSION_ARG} -jar "${JARFILE}" "$@"
+  java ${VERSION_ARG} -Dlog4j.configuration=file:target/conf/log4j.xml -jar "${JARFILE}" "$@"
 fi
 
 exit $?

--- a/target/conf/log4j.xml
+++ b/target/conf/log4j.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration PUBLIC "-//LOGGER" "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+    <!-- Appenders -->
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.err" />
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%t %-5p: %c - %m%n" />
+        </layout>
+    </appender>
+
+    <appender name="file" class="org.apache.log4j.FileAppender">
+        <param name="File" value="/var/log/s3s3mirror.log" />
+        <param name="Append" value="true" />
+        <layout class="org.apache.log4j.PatternLayout">
+          <param name="ConversionPattern" value="%t %-5p %c{2} - %m%n"/>
+        </layout>           
+     </appender>
+
+    <!-- our loggers -->
+    <logger name="org.cobbzilla">
+        <level value="info" />
+    </logger>
+
+    <!-- Root Logger -->
+    <root>
+        <priority value="info" />
+        <appender-ref ref="console" />
+        <appender-ref ref="file" />
+    </root>
+
+</log4j:configuration>


### PR DESCRIPTION
By specifying the log4j.configurationfile parameter, it is possible to configure different log4j options without recompiling the jar.

I also added a sample .xml configuration file which logs to /var/log/s3s3mirror.log as well as console.