### PR TITLE
Add support for --profile parameter and ~/.aws/config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dependency-reduced-pom.xml
 target
 !target/*.jar
 *.log
+.settings
+.classpath
+.project

--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyCopyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyCopyJob.java
@@ -143,8 +143,18 @@ public class KeyCopyJob extends KeyJob {
     }
 
     boolean objectChanged(ObjectMetadata metadata) {
-        final KeyFingerprint sourceFingerprint = new KeyFingerprint(summary.getSize(), summary.getETag());
-        final KeyFingerprint destFingerprint = new KeyFingerprint(metadata.getContentLength(), metadata.getETag());
+        final MirrorOptions options = context.getOptions();
+        final KeyFingerprint sourceFingerprint;
+        final KeyFingerprint destFingerprint;
+        
+        if (options.isSizeOnly()) {
+            sourceFingerprint = new KeyFingerprint(summary.getSize());
+            destFingerprint = new KeyFingerprint(metadata.getContentLength());
+        } else {
+            sourceFingerprint = new KeyFingerprint(summary.getSize(), summary.getETag());
+            destFingerprint = new KeyFingerprint(metadata.getContentLength(), metadata.getETag());
+        }
+
         return !sourceFingerprint.equals(destFingerprint);
     }
 }

--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyFingerprint.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyFingerprint.java
@@ -7,5 +7,9 @@ public class KeyFingerprint {
 
     @Getter private final long size;
     @Getter private final String etag;
+   
+    public KeyFingerprint(long size) {
+        this(size, null);
+    }
 
 }

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -104,6 +104,12 @@ public class MirrorOptions implements AWSCredentials {
     public static final String LONGOPT_MAX_RETRIES = "--max-retries";
     @Option(name=OPT_MAX_RETRIES, aliases=LONGOPT_MAX_RETRIES, usage=USAGE_MAX_RETRIES)
     @Getter @Setter private int maxRetries = 5;
+    
+    public static final String USAGE_SIZE_ONLY = "Only use object size when checking for equality and ignore etags";
+    public static final String OPT_SIZE_ONLY = "-S";
+    public static final String LONGOPT_SIZE_ONLY = "--size-only";
+    @Option(name=OPT_SIZE_ONLY, aliases=LONGOPT_SIZE_ONLY, usage=USAGE_SIZE_ONLY)
+    @Getter @Setter private boolean sizeOnly = false;
 
     public static final String USAGE_CTIME = "Only copy objects whose Last-Modified date is younger than this many days. " +
             "For other time units, use these suffixes: y (years), M (months), d (days), w (weeks), h (hours), m (minutes), s (seconds)";

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -1,7 +1,6 @@
 package org.cobbzilla.s3s3mirror;
 
 import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.services.s3.model.StorageClass;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -23,6 +22,12 @@ public class MirrorOptions implements AWSCredentials {
     @Getter @Setter private String aWSSecretKey = System.getenv().get(AWS_SECRET_KEY);
 
     public boolean hasAwsKeys() { return aWSAccessKeyId != null && aWSSecretKey != null; }
+
+    public static final String USAGE_PROFILE= "Use a specific profile from your credential file (~/.aws/config)";
+    public static final String OPT_PROFILE= "-P";
+    public static final String LONGOPT_PROFILE = "--profile";
+    @Option(name=OPT_PROFILE, aliases=LONGOPT_PROFILE, usage=USAGE_PROFILE)
+    @Getter @Setter private String profile = null;
 
     public static final String USAGE_DRY_RUN = "Do not actually do anything, but show what would be done";
     public static final String OPT_DRY_RUN = "-n";


### PR DESCRIPTION
Change 786ad7a is for if you use the AWS CLI (http://aws.amazon.com/cli/) "configure" command, then your credentials are stored in ~/.aws/config and accessed with the aws "--profile" parameter. Added similar parameter and support for this configuration file (mainly so that I don't have to maintain duplicate credentials on my system).