### PR TITLE
Multiplying by an int results in an int

### DIFF
--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorConstants.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorConstants.java
@@ -2,11 +2,11 @@ package org.cobbzilla.s3s3mirror;
 
 public class MirrorConstants {
 
-    public static final long KB = 1024;
-    public static final long MB = KB * 1024;
-    public static final long GB = MB * 1024;
-    public static final long TB = GB * 1024;
-    public static final long PB = TB * 1024;
-    public static final long EB = PB * 1024;
+    public static final long KB = 1024L;
+    public static final long MB = KB * 1024L;
+    public static final long GB = MB * 1024L;
+    public static final long TB = GB * 1024L;
+    public static final long PB = TB * 1024L;
+    public static final long EB = PB * 1024L;
 
 }


### PR DESCRIPTION
PB and bigger get wrapped as ints in java have a maximum value of 2^31-1.

Behaviour before the patch:
STATS BEGIN
read: 5500000
copied: 3357245
copy errors: 0
deleted: 0
delete errors: 0
duration: 3:08:34
read rate: 29165.490472518064/minute
copy rate: 17802.854011165255/minute
delete rate: 0.0/minute
bytes copied: 885.4553940156475 GB (950750489841 bytes)
GET operations: 12175383
COPY operations: 3366976
DELETE operations: 0
STATS END

Shortly afterwards:
STATS BEGIN
read: 6100000
copied: 3962982
copy errors: 0
deleted: 0
delete errors: 0
duration: 3:38:07
read rate: 27966.618249777202/minute
copy rate: 18169.049954875172/minute
delete rate: 0.0/minute
bytes copied: 1.0421128435264109 PB (1145815188912 bytes)
GET operations: 13991769
COPY operations: 3973972
DELETE operations: 0
STATS END