### PR TITLE
Fixes bug where -i is specified, but an actual access key still needs to be specified

### DIFF
--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorMain.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorMain.java
@@ -98,9 +98,14 @@ public class MirrorMain {
             if (!options.hasAwsKeys() && options.getProfile() != null) loadAwsKeysFromAwsConfig();
             if (!options.hasAwsKeys()) loadAwsKeysFromS3Config();
             if (!options.hasAwsKeys()) loadAwsKeysFromAwsConfig();
-        }
-        if (!options.hasAwsKeys()) {
-            throw new IllegalStateException("Could not find credentials, IAM Role usage not specified and ENV vars not defined: " + MirrorOptions.AWS_ACCESS_KEY + " and/or " + MirrorOptions.AWS_SECRET_KEY);
+            if (!options.hasAwsKeys()) {
+                throw new IllegalStateException("Could not find credentials, IAM Role usage not specified and ENV vars not defined: " + MirrorOptions.AWS_ACCESS_KEY + " and/or " + MirrorOptions.AWS_SECRET_KEY);
+            }
+        } else {
+            InstanceProfileCredentialsProvider client = new InstanceProfileCredentialsProvider();
+            if (client.getCredentials() == null) {
+                throw new IllegalStateException("Could not find IAM Instance Profile credentials from the AWS metadata service.");
+            }
         }
         options.initDerivedFields();
     }


### PR DESCRIPTION
When "-i" or "--iam" is specified, we should not check for whether access keys are specified from s3cfg or the awscli configuration files. 

Instead, we should instantiate a new copy of the AWS InstanceProfileCredentialsProvider and check whether a valid copy of the credential obtained from there.