### PR TITLE
New option --regex-keep to keep the files that match from being deleted

### DIFF
--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyDeleteJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyDeleteJob.java
@@ -79,6 +79,11 @@ public abstract class KeyDeleteJob extends KeyCopyJob {
         try {
             final FileSummary metadata = getMetadata(options.getSourceBucket(), keysrc);
             if (metadata == null) {
+                // check for regex
+                if (options.hasRegexKeep() && options.getRegexPatternKeep().matcher(keysrc).matches()) {
+                    if (options.isVerbose()) getLog().info("shouldDelete: Regex ("+options.getRegexKeep()+") matches keysrc, return false");
+                    return false;
+                }
                 if (options.isVerbose()) getLog().info("Key not found in source bucket (will delete from destination): " + keysrc);
                 return true;
             }

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -87,6 +87,16 @@ public class MirrorOptions implements AWSCredentials {
     @Getter(lazy=true) private final Pattern regexPattern = initRegex();
     private Pattern initRegex() { return hasRegex() ? Pattern.compile(getRegex()) : null; }
 
+    public static final String USAGE_REGEX_KEEP = "If -X is specified, keep the objects on the target whose keys match this regex";
+    public static final String OPT_REGEX_KEEP = "-K";
+    public static final String LONGOPT_REGEX_KEEP = "--regex-keep";
+    @Option(name=OPT_REGEX_KEEP, aliases=LONGOPT_REGEX_KEEP, usage=USAGE_REGEX_KEEP)
+    @Getter @Setter private String regexKeep = null;
+
+    public boolean hasRegexKeep () { return regexKeep != null && regexKeep.length() > 0; }
+    @Getter(lazy=true) private final Pattern regexPatternKeep = initRegexKeep();
+    private Pattern initRegexKeep() { return hasRegexKeep() ? Pattern.compile(getRegexKeep()) : null; }
+
     public static final String AWS_ENDPOINT = "AWS_ENDPOINT";
 
     public static final String USAGE_ENDPOINT = "AWS endpoint to use (or set "+AWS_ENDPOINT+" in your environment)";


### PR DESCRIPTION
Hi John,

Added a new feature to specify a regex that, if specified (together with the -X option), will make sure files that do not exist on the source will be kept on the target (i.e. will be excluded from the removal).

I think it can be useful to other users.

Thank you! This tool is absolutely fantastic and invaluable!