### PR TITLE
better handling of multipart source objects

### DIFF
--- a/src/main/java/org/cobbzilla/s3s3mirror/CopyMaster.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/CopyMaster.java
@@ -16,7 +16,7 @@ public class CopyMaster extends KeyMaster {
     protected String getBucket(MirrorOptions options) { return options.getSourceBucket(); }
 
     protected KeyCopyJob getTask(S3ObjectSummary summary) {
-        if (summary.getSize() > MirrorOptions.MAX_SINGLE_REQUEST_UPLOAD_FILE_SIZE) {
+        if (summary.getSize() > MirrorOptions.MAX_SINGLE_REQUEST_UPLOAD_FILE_SIZE || summary.getETag().contains(MirrorOptions.ETAG_MULTIPART_DELIMITER)) {
             return new MultipartKeyCopyJob(client, context, summary, notifyLock);
         }
         return new KeyCopyJob(client, context, summary, notifyLock);

--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyCopyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyCopyJob.java
@@ -133,9 +133,6 @@ public class KeyCopyJob extends KeyJob {
             return false;
         }
 
-        if (summary.getSize() > MirrorOptions.MAX_SINGLE_REQUEST_UPLOAD_FILE_SIZE) {
-            return metadata.getContentLength() != summary.getSize();
-        }
         final boolean objectChanged = objectChanged(metadata);
         if (verbose && !objectChanged) log.info("Destination file is same as source, not copying: "+ key);
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorConstants.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorConstants.java
@@ -9,4 +9,8 @@ public class MirrorConstants {
     public static final long PB = TB * 1024L;
     public static final long EB = PB * 1024L;
 
+    public static final long KiB = 1000L;
+    public static final long MiB = KiB * 1000L;
+    public static final long GiB = MiB * 1000L;
+
 }

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 import org.joda.time.DateTime;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
+import java.util.Arrays;
 
 import java.util.Date;
 
@@ -201,10 +202,21 @@ public class MirrorOptions implements AWSCredentials {
      * Current max file size allowed in amazon is 5 GB. We can try and provide this as an option too.
      */
     public static final long MAX_SINGLE_REQUEST_UPLOAD_FILE_SIZE = 5 * GB;
-    private static final long DEFAULT_PART_SIZE = 4 * GB;
+    public static final long MINIMUM_PART_SIZE = 5 * MB;
+    public static final CharSequence ETAG_MULTIPART_DELIMITER = "-";
+    public static final long DEFAULT_PART_SIZE = 8 * MB;
+    // s3n and Aspera uses special part sizes (this array is not sorted anywhere, so order it!)
+    public static final long[] SPECIAL_PART_SIZES = {
+        7 * MB,
+        67108536,
+        134217696,
+        268434144,
+        268435392,
+        536869740
+    };
     private static final String MULTI_PART_UPLOAD_SIZE_USAGE = "The upload size (in bytes) of each part uploaded as part of a multipart request " +
             "for files that are greater than the max allowed file size of " + MAX_SINGLE_REQUEST_UPLOAD_FILE_SIZE + " bytes ("+(MAX_SINGLE_REQUEST_UPLOAD_FILE_SIZE/GB)+"GB). " +
-            "Defaults to " + DEFAULT_PART_SIZE + " bytes ("+(DEFAULT_PART_SIZE/GB)+"GB).";
+            "Defaults to " + DEFAULT_PART_SIZE + " bytes ("+(DEFAULT_PART_SIZE/MB)+"MB).";
     private static final String OPT_MULTI_PART_UPLOAD_SIZE = "-u";
     private static final String LONGOPT_MULTI_PART_UPLOAD_SIZE = "--upload-part-size";
     @Option(name=OPT_MULTI_PART_UPLOAD_SIZE, aliases=LONGOPT_MULTI_PART_UPLOAD_SIZE, usage=MULTI_PART_UPLOAD_SIZE_USAGE)

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -207,6 +207,7 @@ public class MirrorOptions implements AWSCredentials {
     public static final long DEFAULT_PART_SIZE = 8 * MB;
     // s3n and Aspera uses special part sizes (this array is not sorted anywhere, so order it!)
     public static final long[] SPECIAL_PART_SIZES = {
+        5 * MB,
         7 * MB,
         67108536,
         134217696,

--- a/src/main/java/org/cobbzilla/s3s3mirror/MultipartKeyCopyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MultipartKeyCopyJob.java
@@ -72,10 +72,12 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
 
             // Detect other special cases like s3n and Aspera
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
+                computedPartSize = 1 * MirrorConstants.MB;
                 for (int i = 0; i < MirrorOptions.SPECIAL_PART_SIZES.length; i++) {
-                    computedPartSize = MirrorOptions.SPECIAL_PART_SIZES[i];
                     if (computedPartSize >= MirrorOptions.SPECIAL_PART_SIZES[i]) {
                         break;
+                    } else {
+                        computedPartSize = MirrorOptions.SPECIAL_PART_SIZES[i];
                     }
                 }
             }

--- a/src/main/java/org/cobbzilla/s3s3mirror/MultipartKeyCopyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MultipartKeyCopyJob.java
@@ -62,22 +62,12 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
                 }
             }
 
-            // Detect using MiB notation and the power of 2
-            if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
-                computedPartSize = 1 * MirrorConstants.MiB;
-                while (computedPartSize < minPartSize) {
-                    computedPartSize *= 2;
-                }
-            }
-
             // Detect other special cases like s3n and Aspera
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
-                computedPartSize = 1 * MirrorConstants.MB;
                 for (int i = 0; i < MirrorOptions.SPECIAL_PART_SIZES.length; i++) {
-                    if (computedPartSize >= MirrorOptions.SPECIAL_PART_SIZES[i]) {
+                    computedPartSize = MirrorOptions.SPECIAL_PART_SIZES[i];
+                    if (computedPartSize >= maxPartSize) {
                         break;
-                    } else {
-                        computedPartSize = MirrorOptions.SPECIAL_PART_SIZES[i];
                     }
                 }
             }
@@ -93,7 +83,7 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             // Detect if using 25MB increments up to 1GB
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 25 * MirrorConstants.MB;
-                while (computedPartSize < minPartSize || computedPartSize < 1 * MirrorConstants.GB) {
+                while (computedPartSize < minPartSize && computedPartSize < 1 * MirrorConstants.GB) {
                     computedPartSize += 25 * MirrorConstants.MB;
                 }
             }
@@ -101,7 +91,7 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             // Detect if using 10MB increments up to 1GB
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 10 * MirrorConstants.MB;
-                while (computedPartSize < minPartSize || computedPartSize < 1 * MirrorConstants.GB) {
+                while (computedPartSize < minPartSize && computedPartSize < 1 * MirrorConstants.GB) {
                     computedPartSize += 10 * MirrorConstants.MB;
                 }
             }
@@ -109,16 +99,8 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             // Detect if using 5MB increments up to 1GB
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 5 * MirrorConstants.MB;
-                while (computedPartSize < minPartSize || computedPartSize < 1 * MirrorConstants.GB) {
+                while (computedPartSize < minPartSize && computedPartSize < 1 * MirrorConstants.GB) {
                     computedPartSize += 5 * MirrorConstants.MB;
-                }
-            }
-
-            // Detect if using 1MB increments up to 100MB
-            if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
-                computedPartSize = 1 * MirrorConstants.MB;
-                while (computedPartSize < minPartSize || computedPartSize < 100 * MirrorConstants.MB) {
-                    computedPartSize += 1 * MirrorConstants.MB;
                 }
             }
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/MultipartKeyCopyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MultipartKeyCopyJob.java
@@ -86,7 +86,7 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 100 * MirrorConstants.MB;
                 while (computedPartSize < minPartSize) {
-                    computedPartSize ++;
+                    computedPartSize += 100 * MirrorConstants.MB;
                 }
             }
 
@@ -94,7 +94,7 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 25 * MirrorConstants.MB;
                 while (computedPartSize < minPartSize || computedPartSize < 1 * MirrorConstants.GB) {
-                    computedPartSize ++;
+                    computedPartSize += 25 * MirrorConstants.MB;
                 }
             }
 
@@ -102,7 +102,7 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 10 * MirrorConstants.MB;
                 while (computedPartSize < minPartSize || computedPartSize < 1 * MirrorConstants.GB) {
-                    computedPartSize ++;
+                    computedPartSize += 10 * MirrorConstants.MB;
                 }
             }
 
@@ -110,7 +110,7 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 5 * MirrorConstants.MB;
                 while (computedPartSize < minPartSize || computedPartSize < 1 * MirrorConstants.GB) {
-                    computedPartSize ++;
+                    computedPartSize += 5 * MirrorConstants.MB;
                 }
             }
 
@@ -118,7 +118,7 @@ public class MultipartKeyCopyJob extends KeyCopyJob {
             if (computedPartSize < minPartSize || computedPartSize > maxPartSize) {
                 computedPartSize = 1 * MirrorConstants.MB;
                 while (computedPartSize < minPartSize || computedPartSize < 100 * MirrorConstants.MB) {
-                    computedPartSize ++;
+                    computedPartSize += 1 * MirrorConstants.MB;
                 }
             }
 


### PR DESCRIPTION
Keeping the source part size on copy operation is very important, because is the single method to keep the eTag metadata parameter intact.
The detection works on multiple levels, from MB at the power of 2, MiB at the power of 2, increments of 100MB, 25MB, 10MB, 5MB to exotic part sizes from s3n or aspera.
The function override for determining if a multipart object has not been changed only by looking at the object size has been removed, since it's not relevant anymore.
