### PR TITLE
Use AWSCredentialProviderChain for S3Client (2.1-stable branch)

### DIFF
--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -1,6 +1,7 @@
 package org.cobbzilla.s3s3mirror;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.services.s3.model.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -29,6 +30,8 @@ public class MirrorOptions implements AWSCredentials {
     @Getter @Setter private String aWSSecretKey = System.getenv().get(AWS_SECRET_KEY);
 
     public boolean hasAwsKeys() { return aWSAccessKeyId != null && aWSSecretKey != null; }
+
+    @Getter @Setter private AWSCredentialsProviderChain awsCredentialProviders;
 
     public static final String USAGE_DRY_RUN = "Do not actually do anything, but show what would be done";
     public static final String OPT_DRY_RUN = "-n";

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/s3/S3ClientService.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/s3/S3ClientService.java
@@ -30,7 +30,7 @@ public class S3ClientService {
                     .withProxyPort(options.getProxyPort());
         }
 
-        final AmazonS3Client client = new AmazonS3Client(options, clientConfiguration);
+        final AmazonS3Client client = new AmazonS3Client(options.getAwsCredentialProviders(), clientConfiguration);
         if (options.hasEndpoint()) client.setEndpoint(options.getEndpoint());
 
         return client;


### PR DESCRIPTION
Allows proper use of AWS credentials the way any other aws cli tool does.

For #93 

I tested this branch and my multiple-hour moves were completing uninterrupted thanks to the credential provider automatically refreshing the session when it expired in the middle of a run.

For use with a specific profile I set `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` env vars only.

Built and tested with OpenJDK 8:
```
openjdk version "1.8.0_102"
OpenJDK Runtime Environment (Zulu 8.17.0.3-macosx) (build 1.8.0_102-b14)
OpenJDK 64-Bit Server VM (Zulu 8.17.0.3-macosx) (build 25.102-b14, mixed mode)
```