### PR TITLE
Ability to Use Jar as a Library Bundled in Other Tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,41 +118,55 @@
                     <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.cobbzilla.s3s3mirror.MirrorMain</mainClass>
-                                </transformer>
-                            </transformers>
-                            <!-- Exclude signed jars to avoid errors
-                            see: http://stackoverflow.com/a/6743609/1251543
-                            -->
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>base</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+        <profile>
+            <id>uberjar</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>2.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>org.cobbzilla.s3s3mirror.MirrorMain</mainClass>
+                                        </transformer>
+                                    </transformers>
+                                    <!-- Exclude signed jars to avoid errors
+                                    see: http://stackoverflow.com/a/6743609/1251543
+                                    -->
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -107,14 +107,14 @@
 
     <build>
         <plugins>
-            <!-- Force Java 1.7 at all times -->
+            <!-- Force Java 1.8 at all times -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                     <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.cobbzilla</groupId>
     <artifactId>s3s3mirror</artifactId>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.1.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/s3s3mirror.bat
+++ b/s3s3mirror.bat
@@ -1,2 +1,2 @@
 @echo off
-java -Ds3s3mirror.version=2.1.4 -jar target/s3s3mirror-2.1.4-SNAPSHOT.jar %*
+java -Ds3s3mirror.version=2.1.5 -jar target/s3s3mirror-2.1.4-SNAPSHOT.jar %*

--- a/s3s3mirror.sh
+++ b/s3s3mirror.sh
@@ -3,7 +3,7 @@
 
 THISDIR=$(cd "$(dirname $0)" && pwd)
 
-VERSION=2.1.4
+VERSION=2.1.5
 JARFILE="${THISDIR}/target/s3s3mirror-${VERSION}-SNAPSHOT.jar"
 VERSION_ARG="-Ds3s3mirror.version=${VERSION}"
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/BucketMirrorMaker.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/BucketMirrorMaker.java
@@ -1,0 +1,17 @@
+package org.cobbzilla.s3s3mirror;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
+
+public class BucketMirrorMaker {
+
+    public MirrorStats makeCopy(MirrorOptions options) {
+        options.initDerivedFields();
+        options.setAwsCredentialProviders(new DefaultAWSCredentialsProviderChain());
+
+        MirrorContext context = new MirrorContext(options);
+        MirrorMaster mirrorMaster = new MirrorMaster(context);
+
+        return mirrorMaster.mirror();
+    }
+}

--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyCopyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyCopyJob.java
@@ -64,12 +64,12 @@ public abstract class KeyCopyJob implements KeyJob {
                     if (options.isVerbose()) getLog().info("successfully copied "+key+" -> "+getKeyDestination());
                     context.getStats().objectsCopied.incrementAndGet();
                 } else {
-                    context.getStats().copyErrors.incrementAndGet();
+                    context.getStats().addErroredCopy(this);
                 }
             }
         } catch (Exception e) {
             getLog().error("error copying key: " + key + ": " + e);
-            if (!options.isDryRun()) context.getStats().copyErrors.incrementAndGet();
+            if (!options.isDryRun()) context.getStats().addErroredCopy(this);
 
         } finally {
             synchronized (notifyLock) {
@@ -169,5 +169,15 @@ public abstract class KeyCopyJob implements KeyJob {
 
         if (verbose) getLog().info("shouldTransfer: destination key ("+getKeyDestination()+") differs from source, return true for key: "+key);
         return true;
+    }
+
+    @Override
+    public String getSource() {
+        return summary.getKey();
+    }
+
+    @Override
+    public String getDestination() {
+        return keyDestination;
     }
 }

--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyDeleteJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyDeleteJob.java
@@ -1,6 +1,7 @@
 package org.cobbzilla.s3s3mirror;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 import org.cobbzilla.s3s3mirror.store.FileSummary;
 
 public abstract class KeyDeleteJob extends KeyCopyJob {
@@ -56,13 +57,13 @@ public abstract class KeyDeleteJob extends KeyCopyJob {
                 if (deletedOK) {
                     stats.objectsDeleted.incrementAndGet();
                 } else {
-                    stats.deleteErrors.incrementAndGet();
+                    stats.addErroredDelete(this);
                 }
             }
 
         } catch (Exception e) {
             getLog().error("error deleting key: "+key+": "+e);
-            if (!options.isDryRun()) context.getStats().deleteErrors.incrementAndGet();
+            if (!options.isDryRun()) context.getStats().addErroredDelete(this);
 
         } finally {
             synchronized (notifyLock) {

--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyJob.java
@@ -1,5 +1,6 @@
 package org.cobbzilla.s3s3mirror;
 
 public interface KeyJob extends Runnable {
-
+    String getSource();
+    String getDestination();
 }

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorContext.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorContext.java
@@ -3,6 +3,7 @@ package org.cobbzilla.s3s3mirror;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 
 @AllArgsConstructor
 public class MirrorContext {

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorMaster.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorMaster.java
@@ -39,9 +39,10 @@ public class MirrorMaster {
 
         if (context.getOptions().getStatusListener() != null) {
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+            long rateInMillis = context.getOptions().getStatusListener().getUpdateInterval().toMillis();
             scheduledExecutorService.scheduleAtFixedRate(() -> context.getOptions().getStatusListener().provideStatus(context.getStats().copy()),
-                                                         0L,
-                                                         context.getOptions().getStatusListener().getUpdateInterval().toMillis(),
+                                                         rateInMillis,
+                                                         rateInMillis,
                                                          TimeUnit.MILLISECONDS);
         }
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/MirrorOptions.java
@@ -3,10 +3,14 @@ package org.cobbzilla.s3s3mirror;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.services.s3.model.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.cobbzilla.s3s3mirror.stats.StatusListener;
 import org.joda.time.DateTime;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
@@ -18,6 +22,9 @@ import java.util.regex.Pattern;
 import static org.cobbzilla.s3s3mirror.MirrorConstants.GB;
 
 @Slf4j
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MirrorOptions implements AWSCredentials {
 
     public static final String S3_PROTOCOL_PREFIX = "s3://";
@@ -33,34 +40,42 @@ public class MirrorOptions implements AWSCredentials {
 
     @Getter @Setter private AWSCredentialsProviderChain awsCredentialProviders;
 
+    @Getter @Setter private boolean detailedErrorLogging;
+    @Getter @Setter private StatusListener statusListener;
+
     public static final String USAGE_DRY_RUN = "Do not actually do anything, but show what would be done";
     public static final String OPT_DRY_RUN = "-n";
     public static final String LONGOPT_DRY_RUN = "--dry-run";
     @Option(name=OPT_DRY_RUN, aliases=LONGOPT_DRY_RUN, usage=USAGE_DRY_RUN)
+    @Builder.Default
     @Getter @Setter private boolean dryRun = false;
 
     public static final String USAGE_VERBOSE = "Verbose output";
     public static final String OPT_VERBOSE = "-v";
     public static final String LONGOPT_VERBOSE = "--verbose";
     @Option(name=OPT_VERBOSE, aliases=LONGOPT_VERBOSE, usage=USAGE_VERBOSE)
+    @Builder.Default
     @Getter @Setter private boolean verbose = false;
 
     public static final String USAGE_SSL = "Use SSL for all S3 api operations";
     public static final String OPT_SSL = "-s";
     public static final String LONGOPT_SSL = "--ssl";
     @Option(name=OPT_SSL, aliases=LONGOPT_SSL, usage=USAGE_SSL)
+    @Builder.Default
     @Getter @Setter private boolean ssl = false;
 
     public static final String USAGE_ENCRYPT = "Enable AWS managed server-side encryption";
     public static final String OPT_ENCRYPT = "-E";
     public static final String LONGOPT_ENCRYPT = "--server-side-encryption";
     @Option(name=OPT_ENCRYPT, aliases=LONGOPT_ENCRYPT, usage=USAGE_ENCRYPT)
+    @Builder.Default
     @Getter @Setter private boolean encrypt = false;
 
     public static final String USAGE_STORAGE_CLASS = "The S3 StorageClass (default Standard)";
     public static final String OPT_STORAGE_CLASS = "-l";
     public static final String LONGOPT_STORAGE_CLASS = "--storage-class";
     @Option(name=OPT_STORAGE_CLASS, aliases=LONGOPT_STORAGE_CLASS, usage=USAGE_STORAGE_CLASS)
+    @Builder.Default
     @Getter @Setter private S3StorageClass storageClass = S3StorageClass.Standard;
 
     public static final String USAGE_PREFIX = "Only copy objects whose keys start with this prefix";
@@ -97,6 +112,7 @@ public class MirrorOptions implements AWSCredentials {
     public static final String OPT_ENDPOINT = "-e";
     public static final String LONGOPT_ENDPOINT = "--endpoint";
     @Option(name=OPT_ENDPOINT, aliases=LONGOPT_ENDPOINT, usage=USAGE_ENDPOINT)
+    @Builder.Default
     @Getter @Setter private String endpoint = System.getenv().get(AWS_ENDPOINT);
 
     public boolean hasEndpoint () { return endpoint != null && endpoint.trim().length() > 0; }
@@ -105,18 +121,21 @@ public class MirrorOptions implements AWSCredentials {
     public static final String OPT_MAX_CONNECTIONS = "-m";
     public static final String LONGOPT_MAX_CONNECTIONS = "--max-connections";
     @Option(name=OPT_MAX_CONNECTIONS, aliases=LONGOPT_MAX_CONNECTIONS, usage=USAGE_MAX_CONNECTIONS)
+    @Builder.Default
     @Getter @Setter private int maxConnections = 100;
 
     public static final String USAGE_MAX_THREADS = "Maximum number of threads (default 100)";
     public static final String OPT_MAX_THREADS = "-t";
     public static final String LONGOPT_MAX_THREADS = "--max-threads";
     @Option(name=OPT_MAX_THREADS, aliases=LONGOPT_MAX_THREADS, usage=USAGE_MAX_THREADS)
+    @Builder.Default
     @Getter @Setter private int maxThreads = 100;
 
     public static final String USAGE_MAX_RETRIES = "Maximum number of retries for S3 requests (default 5)";
     public static final String OPT_MAX_RETRIES = "-r";
     public static final String LONGOPT_MAX_RETRIES = "--max-retries";
     @Option(name=OPT_MAX_RETRIES, aliases=LONGOPT_MAX_RETRIES, usage=USAGE_MAX_RETRIES)
+    @Builder.Default
     @Getter @Setter private int maxRetries = 5;
 
     public static final String USAGE_CTIME = "Only copy objects whose Last-Modified date is younger than this many days. " +
@@ -150,6 +169,7 @@ public class MirrorOptions implements AWSCredentials {
         }
     }
     @Getter @Setter public String proxyHost = null;
+    @Builder.Default
     @Getter @Setter public int proxyPort = -1;
 
     public boolean getHasProxy() { return proxyHost != null && proxyHost.trim().length() > 0; }
@@ -186,6 +206,7 @@ public class MirrorOptions implements AWSCredentials {
     public static final String OPT_DELETE_REMOVED = "-X";
     public static final String LONGOPT_DELETE_REMOVED = "--delete-removed";
     @Option(name=OPT_DELETE_REMOVED, aliases=LONGOPT_DELETE_REMOVED, usage=USAGE_DELETE_REMOVED)
+    @Builder.Default
     @Getter @Setter private boolean deleteRemoved = false;
 
     @Argument(index=0, required=true, usage="source bucket[/source/prefix]") @Getter @Setter private String source;
@@ -205,6 +226,7 @@ public class MirrorOptions implements AWSCredentials {
     private static final String OPT_MULTI_PART_UPLOAD_SIZE = "-u";
     private static final String LONGOPT_MULTI_PART_UPLOAD_SIZE = "--upload-part-size";
     @Option(name=OPT_MULTI_PART_UPLOAD_SIZE, aliases=LONGOPT_MULTI_PART_UPLOAD_SIZE, usage=MULTI_PART_UPLOAD_SIZE_USAGE)
+    @Builder.Default
     @Getter @Setter private long uploadPartSize = DEFAULT_PART_SIZE;
 
     private static final String CROSS_ACCOUNT_USAGE ="Copy across AWS accounts. Only Resource-based policies are supported (as " +
@@ -214,6 +236,7 @@ public class MirrorOptions implements AWSCredentials {
     private static final String OPT_CROSS_ACCOUNT_COPY = "-C";
     private static final String LONGOPT_CROSS_ACCOUNT_COPY = "--cross-account-copy";
     @Option(name=OPT_CROSS_ACCOUNT_COPY, aliases=LONGOPT_CROSS_ACCOUNT_COPY, usage=CROSS_ACCOUNT_USAGE)
+    @Builder.Default
     @Getter @Setter private boolean crossAccountCopy = false;
 
     public void initDerivedFields() {

--- a/src/main/java/org/cobbzilla/s3s3mirror/stats/FailedOperation.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/stats/FailedOperation.java
@@ -1,0 +1,9 @@
+package org.cobbzilla.s3s3mirror.stats;
+
+import lombok.Value;
+
+@Value
+public class FailedOperation {
+    private final String source;
+    private final String destination;
+}

--- a/src/main/java/org/cobbzilla/s3s3mirror/stats/MirrorStats.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/stats/MirrorStats.java
@@ -47,9 +47,9 @@ public class MirrorStats {
     }
 
     public String toString () {
-        final long durationMillis = System.currentTimeMillis() - start;
+        final long durationMillis = getDurationInMilliseconds();
         final double durationMinutes = durationMillis / 60000.0d;
-        final String duration = String.format("%d:%02d:%02d", durationMillis / HOUR, (durationMillis % HOUR) / MINUTE, (durationMillis % MINUTE) / SECOND);
+        final String duration = getDurationFormatted();
         final double readRate = objectsRead.get() / durationMinutes;
         final double copyRate = (objectsCopied.get() + objectsPut.get()) / durationMinutes;
         final double deleteRate = objectsDeleted.get() / durationMinutes;
@@ -93,6 +93,15 @@ public class MirrorStats {
         if (logFailedOperationInfo.get()) {
             failedDeletes.add(new FailedOperation(failedObject.getSource(), failedObject.getDestination()));
         }
+    }
+
+    public long getDurationInMilliseconds() {
+        return System.currentTimeMillis() - start;
+    }
+
+    public String getDurationFormatted() {
+        final long durationMillis = getDurationInMilliseconds();
+        return String.format("%d:%02d:%02d", durationMillis / HOUR, (durationMillis % HOUR) / MINUTE, (durationMillis % MINUTE) / SECOND);
     }
 
     public MirrorStats copy() {

--- a/src/main/java/org/cobbzilla/s3s3mirror/stats/StatusListener.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/stats/StatusListener.java
@@ -1,0 +1,8 @@
+package org.cobbzilla.s3s3mirror.stats;
+
+import java.time.Duration;
+
+public interface StatusListener {
+    Duration getUpdateInterval();
+    void provideStatus(MirrorStats mirrorStats);
+}

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/FileStore.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/FileStore.java
@@ -1,6 +1,6 @@
 package org.cobbzilla.s3s3mirror.store;
 
-import org.cobbzilla.s3s3mirror.MirrorStats;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 
 public interface FileStore {
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/local/LocalFileStore.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/local/LocalFileStore.java
@@ -3,7 +3,7 @@ package org.cobbzilla.s3s3mirror.store.local;
 import lombok.extern.slf4j.Slf4j;
 import org.cobbzilla.s3s3mirror.FileStoreFactory;
 import org.cobbzilla.s3s3mirror.MirrorOptions;
-import org.cobbzilla.s3s3mirror.MirrorStats;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 import org.cobbzilla.s3s3mirror.store.FileListing;
 import org.cobbzilla.s3s3mirror.store.FileStore;
 import org.cobbzilla.s3s3mirror.store.ListRequest;

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/local/job/LocalS3KeyLinkJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/local/job/LocalS3KeyLinkJob.java
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.apache.commons.io.input.NullInputStream;
 import org.cobbzilla.s3s3mirror.MirrorContext;
 import org.cobbzilla.s3s3mirror.MirrorOptions;
-import org.cobbzilla.s3s3mirror.MirrorStats;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 import org.cobbzilla.s3s3mirror.store.FileSummary;
 import org.cobbzilla.s3s3mirror.store.s3.job.S3KeyUploadJob;
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/s3/S3FileStore.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/s3/S3FileStore.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.cobbzilla.s3s3mirror.MirrorContext;
 import org.cobbzilla.s3s3mirror.MirrorOptions;
-import org.cobbzilla.s3s3mirror.MirrorStats;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 import org.cobbzilla.s3s3mirror.store.FileListing;
 import org.cobbzilla.s3s3mirror.store.FileStore;
 import org.cobbzilla.s3s3mirror.store.ListRequest;

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/s3/job/S3CopyToLocalJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/s3/job/S3CopyToLocalJob.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.cobbzilla.s3s3mirror.MirrorContext;
 import org.cobbzilla.s3s3mirror.MirrorOptions;
-import org.cobbzilla.s3s3mirror.MirrorStats;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 import org.cobbzilla.s3s3mirror.Sha256;
 import org.cobbzilla.s3s3mirror.store.FileSummary;
 import org.cobbzilla.s3s3mirror.store.local.LocalFileStore;

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/s3/job/S3KeyCopyJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/s3/job/S3KeyCopyJob.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.cobbzilla.s3s3mirror.KeyCopyJob;
 import org.cobbzilla.s3s3mirror.MirrorContext;
 import org.cobbzilla.s3s3mirror.MirrorOptions;
-import org.cobbzilla.s3s3mirror.MirrorStats;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 import org.cobbzilla.s3s3mirror.store.FileSummary;
 import org.cobbzilla.s3s3mirror.store.s3.S3FileListing;
 import org.slf4j.Logger;

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/s3/job/S3KeyUploadJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/s3/job/S3KeyUploadJob.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.cobbzilla.s3s3mirror.MirrorContext;
 import org.cobbzilla.s3s3mirror.MirrorOptions;
-import org.cobbzilla.s3s3mirror.MirrorStats;
+import org.cobbzilla.s3s3mirror.stats.MirrorStats;
 import org.cobbzilla.s3s3mirror.Sha256;
 import org.cobbzilla.s3s3mirror.store.FileSummary;
 import org.cobbzilla.s3s3mirror.store.local.LocalFileStore;


### PR DESCRIPTION
There will be merge conflicts between this and my earlier PR https://github.com/cobbzilla/s3s3mirror/pull/112 they will be easy enough to fix after the first one gets merged. Wanted to open the PR now though to start the conversation.

The PR adds the ability to call this jar from another Java library (via BucketMirrorMaker). This library, in it's form before the PR, was very focused on being driven via the command line with all output going out via that interface. This makes sense with how it's been used before; however, my goal has been to bundle this library as just part of a larger tool. 

This change creates an easy entry point that handles being called via something other than MirrorMain. It also creates a way to get the results of the copy at the end of the copy as well as periodically during the copy.

To be of the most utility this library would also be deployed to a public maven repository as a non-uber jar but that would likely be a chunk of work for you and I should be able to work around it for my use case. 

A bare minimum usage of this could look something like:
```java
  BucketMirrorMaker mirrorMaker = new BucketMirrorMaker();

  MirrorOptions options = MirrorOptions.builder()
                                       .source("kcarter-source")
                                       .destination("kcarter-target")
                                       .detailedErrorLogging(true)
                                       .statusListener(new ExampleStatusListener())
                                       .syncStrategy(SyncStrategy.SIZE_LAST_MODIFIED)
                                       .build();

  MirrorStats stats = mirrorMaker.makeCopy(options);

  System.out.println("Done:");
  System.out.println(stats);
  System.out.println("Error copies:");
  System.out.println(stats.getFailedCopies());
  System.out.println("Error delete:");
  System.out.println(stats.getFailedDeletes());
```

```java
public class ExampleStatusListener implements StatusListener {
    @Override
    public Duration getUpdateInterval() {
        return Duration.ofSeconds(10);
    }

    @Override
    public void provideStatus(MirrorStats mirrorStats) {
        System.out.println(mirrorStats);
    }
}
```