### PR TITLE
When Using Prefixes With Deletion Copies Objects are Deleted When They Shouldn't Be

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.cobbzilla</groupId>
     <artifactId>s3s3mirror</artifactId>
-    <version>2.1.5-SNAPSHOT</version>
+    <version>2.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/s3s3mirror.bat
+++ b/s3s3mirror.bat
@@ -1,2 +1,2 @@
 @echo off
-java -Ds3s3mirror.version=2.1.5 -jar target/s3s3mirror-2.1.4-SNAPSHOT.jar %*
+java -Ds3s3mirror.version=2.1.6 -jar target/s3s3mirror-2.1.4-SNAPSHOT.jar %*

--- a/s3s3mirror.sh
+++ b/s3s3mirror.sh
@@ -3,7 +3,7 @@
 
 THISDIR=$(cd "$(dirname $0)" && pwd)
 
-VERSION=2.1.5
+VERSION=2.1.6
 JARFILE="${THISDIR}/target/s3s3mirror-${VERSION}-SNAPSHOT.jar"
 VERSION_ARG="-Ds3s3mirror.version=${VERSION}"
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/KeyDeleteJob.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/KeyDeleteJob.java
@@ -14,9 +14,13 @@ public abstract class KeyDeleteJob extends KeyCopyJob {
 
         final MirrorOptions options = context.getOptions();
         keysrc = summary.getKey(); // NOTE: summary.getKey is the key in the destination bucket
-        if (options.hasPrefix()) {
+
+        if (options.hasDestPrefix()) {
             keysrc = keysrc.substring(options.getDestPrefixLength());
-            keysrc = options.getPrefix() + keyDestination;
+        }
+
+        if (options.hasPrefix()) {
+            keysrc = options.getPrefix() + keysrc;
         }
     }
 

--- a/src/main/java/org/cobbzilla/s3s3mirror/store/s3/master/S3DeleteMaster.java
+++ b/src/main/java/org/cobbzilla/s3s3mirror/store/s3/master/S3DeleteMaster.java
@@ -20,7 +20,7 @@ public class S3DeleteMaster extends S3Master {
     }
 
     @Override protected String getPrefix(MirrorOptions options) {
-        return options.hasDestPrefix() ? options.getDestPrefix() : options.getPrefix();
+        return options.hasDestPrefix() ? options.getDestPrefix() : "";
     }
 
     @Override protected String getBucket(MirrorOptions options) { return options.getDestinationBucket(); }


### PR DESCRIPTION
As I have started to use additional features of the library I have noticed that if I include prefixes along with the ` --delete-removed` I noticed that the objects would be deleted before they were copied over again. This of course defeats much of the purpose of doing the sync as well as inflates the site of the bucket when versioning is enabled. Digging in it turned outto be small issues that are represented in this PR to fix the issue.